### PR TITLE
Remove the need to pass a zip file to the stapler

### DIFF
--- a/Sources/applenotary/NotarizationHistory.swift
+++ b/Sources/applenotary/NotarizationHistory.swift
@@ -1,0 +1,22 @@
+//
+//  NotarizationHistory.swift
+//  applenotary
+//
+//  Created by Adam Findley on 7/31/19.
+//
+import Foundation
+
+struct NotarizationHistory: Decodable {
+
+    private enum CodingKeys: String, CodingKey {
+        case firstPage = "first-page"
+        case items = "items"
+        case nextPage = "next-page"
+        case lastPage = "last-page"
+    }
+
+    var firstPage: Int?
+    var items: [NotarizationInfo]?
+    var nextPage: Int?
+    var lastPage: Int?
+}

--- a/Sources/applenotary/NotarizationInfo.swift
+++ b/Sources/applenotary/NotarizationInfo.swift
@@ -18,7 +18,6 @@ struct NotarizationInfo: Decodable {
         
     }
     
-    
     var date: Date?
     var logFileUrl: String?
     var requestUUID: String?

--- a/Sources/applenotary/Notarize.swift
+++ b/Sources/applenotary/Notarize.swift
@@ -1,0 +1,164 @@
+//
+//  Notarize.swift
+//  applenotary
+//
+//  Created by Adam Findley on 7/26/19.
+//
+
+import Foundation
+
+class Notarize {
+    let file: String
+    let stapleFile: String
+    let bundleID: String
+    let username: String
+    let password: String
+
+    required init(file: String, stapleFile: String, bundleID: String, username: String, password: String) {
+        self.file = file
+        self.stapleFile = stapleFile
+        self.bundleID = bundleID
+        self.username = username
+        self.password = password
+    }
+
+    func uploadAndStaple() {
+        let notarizeUploadResponse = upload()
+
+        if let uuid = notarizeUploadResponse.notarizationUpload?.RequestUUID {
+            print("start observing status")
+
+            waitForProcessing(with: uuid, username: username, password: password)
+        } else {
+            print("show errors")
+            notarizeUploadResponse.productErrors?.forEach { error in
+                print(error)
+            }
+            exit(1)
+
+        }
+    }
+
+    func upload() -> NotarizeUploadResponse {
+        let task = Process()
+        task.launchPath = "/usr/bin/env"
+        task.arguments = [
+            "xcrun", "altool",
+            "-t", "osx",
+            "-f", file,
+            "--primary-bundle-id", bundleID,
+            "-u", username,
+            "-p", password,
+            "--notarize-app",
+            "--output-format", "xml"
+        ]
+
+        let outpipe = Pipe()
+        task.standardOutput = outpipe
+        print("upload")
+        task.launch()
+
+        task.waitUntilExit()
+        print("done uploading, processing result")
+        let outdata = outpipe.fileHandleForReading.readDataToEndOfFile()
+
+        let note = NotarizeUploadResponse.create(from: outdata)
+        print("done processing result")
+        return note
+    }
+
+    func staple(file: String) {
+        print("stapling")
+        sleep(5) //give apple a few to be read to staple
+        //xcrun stapler staple Pluralsight\ -\ Beta.app
+
+        let task = Process()
+        task.launchPath = "/usr/bin/env"
+        task.arguments = [
+            "xcrun", "stapler",
+            "staple", file
+        ]
+
+        let outpipe = Pipe()
+        task.standardOutput = outpipe
+
+        task.launch()
+
+        task.waitUntilExit()
+
+        let outdata = outpipe.fileHandleForReading.readDataToEndOfFile()
+
+        if let string = String(data: outdata, encoding: .utf8) {
+            if string.contains("The staple and validate action worked!") {
+                print("staple success!")
+            } else {
+                print("staple failed: \(string)")
+                exit(1)
+            }
+        } else {
+            print("unable to read out put of staple")
+            exit(1)
+        }
+    }
+
+    func waitForProcessing(with uuid: String, username: String, password: String) {
+        sleep(10)
+
+        let task = Process()
+        task.launchPath = "/usr/bin/env"
+        task.arguments = [
+            "xcrun", "altool",
+            "-u", username,
+            "-p", password,
+            "--notarization-info", uuid,
+            "--output-format", "xml"
+        ]
+
+        let outpipe = Pipe()
+        task.standardOutput = outpipe
+
+        task.launch()
+
+        task.waitUntilExit()
+
+        let outdata = outpipe.fileHandleForReading.readDataToEndOfFile()
+
+        let note = NotarizeUploadResponse.create(from: outdata)
+
+        if let status = note.notarizationInfo?.status {
+            switch status {
+            case .inProgress:
+                print("notarization in progress, continuing to wait")
+                waitForProcessing(with: uuid, username: username, password: password)
+            case .success:
+                print("approved!")
+                staple(file: stapleFile)
+            case .invalid:
+                if let url = note.notarizationInfo?.logFileUrl {
+                    print("the app failed notarization see link for details: \(url)")
+
+                } else {
+                    print("the app failed notarization: \(note)")
+                }
+                exit(1)
+            }
+        } else {
+            if let errors = note.productErrors, errors.contains(where: { $0.code == 1519 }) {
+                print("UUID not found trying again in a few")
+                sleep(10)
+                waitForProcessing(with: uuid, username: username, password: password)
+            } else {
+                if note.productErrors?.isEmpty ?? false {
+                    let outputString = String(data: outdata, encoding: .utf8)
+                    print("an unkown error occurred, showing raw output: \(String(describing: outputString))")
+                } else {
+                    print("an error occured: \(String(describing: note.productErrors))")
+                }
+            }
+
+            //do we have error, is key not found? try again in a second?
+            print("unable to get status")
+            exit(1)
+        }
+    }
+}

--- a/Sources/applenotary/NotarizeUploadResponse.swift
+++ b/Sources/applenotary/NotarizeUploadResponse.swift
@@ -10,6 +10,7 @@ struct NotarizeUploadResponse: Decodable {
         case toolVersion = "tool-version"
         case productErrors = "product-errors"
         case notarizationInfo = "notarization-info"
+        case notarizationHistory = "notarization-history"
     }
     
     static func create(from data: Data) -> NotarizeUploadResponse {
@@ -30,7 +31,7 @@ struct NotarizeUploadResponse: Decodable {
     var toolPath: String
     var toolVersion: String
     var productErrors: [NotaryError]?
-    
+    var notarizationHistory: NotarizationHistory?
     var uploadSuccess: Bool {
         return successMessage != nil
     }

--- a/Sources/applenotary/main.swift
+++ b/Sources/applenotary/main.swift
@@ -3,7 +3,7 @@ import Foundation
 
 var flags = Flags()
 
-let filePath = flags.string("f", "filePathToNotarize", description: "zip or pkg to upload for notarization")
+let filePaths = flags.strings("f", "filePathToNotarize", description: "zip or pkg to upload for notarization")
 let primaryBundleId = flags.string("b", "primary-bundle-id", description: "The primary bundle id of the app being notarized")
 let username = flags.string("u", "username", description: "username for the apple id being used to notarize")
 let password = flags.string("p", "password", description: "password for the apple id being used to notarize")
@@ -11,13 +11,12 @@ let help = flags.option("h", "help", description: "provides this...")
 
 func main() {
     validate()
-    if  let filePath = filePath.value,
-        let primaryBundleId = primaryBundleId.value,
+    if let primaryBundleId = primaryBundleId.value,
         let username = username.value,
         let password = password.value
     {
         let notarize = Notarize(bundleID: primaryBundleId, username: username, password: password)
-        notarize.uploadAndStaple(filePath: filePath)
+        notarize.uploadAndStaple(filePaths: filePaths.value)
     } else {
         print("validation failed, one of the parameters is empty")
     }
@@ -33,8 +32,8 @@ func validate() {
         exit(0)
     }
     
-    guard filePath.wasSet else {
-        print("file path must be set")
+    guard filePaths.wasSet else {
+        print("file paths must be set")
         exit(1)
     }
     

--- a/Sources/applenotary/main.swift
+++ b/Sources/applenotary/main.swift
@@ -12,19 +12,16 @@ let help = flags.option("h", "help", description: "provides this...")
 
 func main() {
     validate()
-    
-    let notarizeUploadResponse = upload(file: filePath.value!, bundleId: primaryBundleId.value!, username: username.value!, password: password.value!)
-    
-    if let uuid = notarizeUploadResponse.notarizationUpload?.RequestUUID {
-        print("start observing status")
-        
-        waitForProcessing(with: uuid, username: username.value!, password: password.value!)
+    if let stapleFilePath = stapleFilePath.value,
+        let filePath = filePath.value,
+        let primaryBundleId = primaryBundleId.value,
+        let username = username.value,
+        let password = password.value
+    {
+        let notarize = Notarize(file: filePath, stapleFile: stapleFilePath, bundleID: primaryBundleId, username: username, password: password)
+        notarize.uploadAndStaple()
     } else {
-        print("show errors")
-        notarizeUploadResponse.productErrors?.forEach { error in
-            print(error)
-        }
-        exit(1)
+        print("validation failed, one of the parameters is empty")
     }
 }
 
@@ -62,130 +59,6 @@ func validate() {
         print("stapleFilePath must be set")
         exit(1)
     }
-}
-
-func upload(file: String, bundleId: String, username: String, password: String) -> NotarizeUploadResponse {
-    let task = Process()
-    task.launchPath = "/usr/bin/env"
-    task.arguments = [
-        "xcrun", "altool",
-        "-t", "osx",
-        "-f", file,
-        "--primary-bundle-id", bundleId,
-        "-u", username,
-        "-p", password,
-        "--notarize-app",
-        "--output-format", "xml"
-    ]
-    
-    let outpipe = Pipe()
-    task.standardOutput = outpipe
-    print("upload")
-    task.launch()
-    
-    task.waitUntilExit()
-    print("done uploading, processing result")
-    let outdata = outpipe.fileHandleForReading.readDataToEndOfFile()
-    
-    let note = NotarizeUploadResponse.create(from: outdata)
-    print("done processing result")
-    return note
-}
-
-func staple(file: String) {
-    print("stapling")
-    sleep(5) //give apple a few to be read to staple
-    //xcrun stapler staple Pluralsight\ -\ Beta.app
-    
-    let task = Process()
-    task.launchPath = "/usr/bin/env"
-    task.arguments = [
-        "xcrun", "stapler",
-        "staple", file
-    ]
-    
-    let outpipe = Pipe()
-    task.standardOutput = outpipe
-    
-    task.launch()
-    
-    task.waitUntilExit()
-    
-    let outdata = outpipe.fileHandleForReading.readDataToEndOfFile()
-    
-    if let string = String(data: outdata, encoding: .utf8) {
-        if string.contains("The staple and validate action worked!") {
-            print("staple success!")
-        } else {
-            print("staple failed: \(string)")
-            exit(1)
-        }
-    } else {
-        print("unable to read out put of staple")
-        exit(1)
-    }
-}
-
-func waitForProcessing(with uuid: String, username: String, password: String) {
-    sleep(10)
-    
-    let task = Process()
-    task.launchPath = "/usr/bin/env"
-    task.arguments = [
-        "xcrun", "altool",
-        "-u", username,
-        "-p", password,
-        "--notarization-info", uuid,
-        "--output-format", "xml"
-    ]
-    
-    let outpipe = Pipe()
-    task.standardOutput = outpipe
-    
-    task.launch()
-    
-    task.waitUntilExit()
-    
-    let outdata = outpipe.fileHandleForReading.readDataToEndOfFile()
-    
-    let note = NotarizeUploadResponse.create(from: outdata)
-    
-    if let status = note.notarizationInfo?.status {
-        switch status {
-        case .inProgress:
-            print("notarization in progress, continuing to wait")
-            waitForProcessing(with: uuid, username: username, password: password)
-        case .success:
-            print("approved!")
-            staple(file: stapleFilePath.value!)
-        case .invalid:
-            if let url = note.notarizationInfo?.logFileUrl {
-                print("the app failed notarization see link for details: \(url)")
-                
-            } else {
-                print("the app failed notarization: \(note)")
-            }
-            exit(1)
-        }
-    } else {
-        if let errors = note.productErrors, errors.contains(where: { $0.code == 1519 }) {
-            print("UUID not found trying again in a few")
-            sleep(10)
-            waitForProcessing(with: uuid, username: username, password: password)
-        } else {
-            if note.productErrors?.isEmpty ?? false {
-                let outputString = String(data: outdata, encoding: .utf8)
-                print("an unkown error occurred, showing raw output: \(String(describing: outputString))")
-            } else {
-                print("an error occured: \(String(describing: note.productErrors))")
-            }
-        }
-        
-        //do we have error, is key not found? try again in a second?
-        print("unable to get status")
-        exit(1)
-    }
-    
 }
 
 print("🎬")

--- a/Sources/applenotary/main.swift
+++ b/Sources/applenotary/main.swift
@@ -3,7 +3,6 @@ import Foundation
 
 var flags = Flags()
 
-let stapleFilePath = flags.string("s", "filePathToStaple", description: "the executable that needs to the notarization stapled to")
 let filePath = flags.string("f", "filePathToNotarize", description: "zip or pkg to upload for notarization")
 let primaryBundleId = flags.string("b", "primary-bundle-id", description: "The primary bundle id of the app being notarized")
 let username = flags.string("u", "username", description: "username for the apple id being used to notarize")
@@ -12,14 +11,13 @@ let help = flags.option("h", "help", description: "provides this...")
 
 func main() {
     validate()
-    if let stapleFilePath = stapleFilePath.value,
-        let filePath = filePath.value,
+    if  let filePath = filePath.value,
         let primaryBundleId = primaryBundleId.value,
         let username = username.value,
         let password = password.value
     {
-        let notarize = Notarize(file: filePath, stapleFile: stapleFilePath, bundleID: primaryBundleId, username: username, password: password)
-        notarize.uploadAndStaple()
+        let notarize = Notarize(bundleID: primaryBundleId, username: username, password: password)
+        notarize.uploadAndStaple(filePath: filePath)
     } else {
         print("validation failed, one of the parameters is empty")
     }
@@ -54,16 +52,8 @@ func validate() {
         print("password must be set... for now")
         exit(1)
     }
-    
-    guard stapleFilePath.wasSet else {
-        print("stapleFilePath must be set")
-        exit(1)
-    }
 }
 
 print("🎬")
 main()
 print("🏁")
-
-
-


### PR DESCRIPTION
In order to simplify things a bit, zip the .app file instead of specifying it by hand. Also, move the notarization code into its own file to separate out concerns.